### PR TITLE
Add post-bootstrap health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The supported environment variables are as follows:
 
 | Environment Variable | Default               | Description                                                                                                                            |
 |----------------------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| CONSUL_HTTP_ADDR     | http://localhost:8500 | Address at which Consul's HTTP listener may be reached. Prefix with `http://` for TCP transport, or `unix://` for UNIX Domain Sockets. |
+| CONSUL_HTTP_ADDR     | http://127.0.0.1:8500 | Address at which Consul's HTTP listener may be reached. Prefix with `http://` for TCP transport, or `unix://` for UNIX Domain Sockets. |
 | CONSUL_HTTP_TOKEN    | None                  | ACL Token to use when connecting to Consul                                                                                             |
 | CONSUL_CLUSTER_SIZE  | None                  | **REQUIRED** Number of instances that should gain voter status before a cluster is considered healthy                                  |
 | CONSUL_HEALTH_PORT   | 8080                  | TCP port for the health check's HTTP server to listen on                                                                               |
@@ -36,11 +36,7 @@ go build
 ...Profit!
 
 ## // TODO:
-- [ ] Create a DefaultHealthCheck struct
-  - Once a cluster is healthy, forward subsequent health checks to a Consul endpoint (e.g. /operator/autopilot/health).
-  - Currently after the cluster has bootstrapped we change state to automatically returning HTTP 200.
 - [ ] Add a commander ([mitchellh/cli](https://github.com/mitchellh/cli) or [spf12/cobra](https://github.com/spf13/cobra)).
 - [ ] Clean up config/environment variable handling.
 - [ ] Add signal handling. Refresh state on SIGHUP.
 - [ ] Make the upgrade version tag configurable. It is currently hard-coded to `consul_cluster_version`.
-- [ ] Add a context to the bootstrap health check process

--- a/handlers.go
+++ b/handlers.go
@@ -18,7 +18,7 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 		if check.IsHealthy(r.Context()) {
 			// Change global state
 			// Once this has succeeded, we switch to a standard health check
-			log.Info("Cluster bootstrapping succeeded! Switching to standard health response.")
+			log.Info("Cluster bootstrapping succeeded! Switching to standard health check.")
 			isBootstrapped = true
 			w.WriteHeader(http.StatusOK)
 			return
@@ -26,5 +26,13 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
+
+	check := health.NodeHealthCheck{
+		Client: consulClient,
+	}
+	if check.IsHealthy() {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	w.WriteHeader(http.StatusServiceUnavailable)
 }

--- a/health/nodeCheck.go
+++ b/health/nodeCheck.go
@@ -1,0 +1,31 @@
+package health
+
+import (
+	"github.com/hashicorp/consul/api"
+	log "github.com/sirupsen/logrus"
+)
+
+// NodeHealthCheck performs a simple cluster/node sign of life test.
+// /v1/status/leader is queried. In the event the node is unable to respond,
+// the node is live but there is no Raft leader, or the API otherwise returns
+// an error, we evaluate the node as Unehalthy.
+type NodeHealthCheck struct {
+	Client *api.Client
+}
+
+// IsHealthy implements the basic boolean test logic described above
+func (hc *NodeHealthCheck) IsHealthy() bool {
+	leader, err := hc.Client.Status().Leader()
+	if err != nil {
+		log.Error("Cluster status returned error: ", err)
+		return false
+	}
+	// If we evaluate this health check on a cluster that has not
+	// yet reached bootstrap_expect, this endpoint returns 200.
+	// To prevent false positive, we check for empty string as well.
+	if leader == "" {
+		log.Error("Cluster reported no Raft leader")
+		return false
+	}
+	return true
+}

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	if addr = os.Getenv("CONSUL_HTTP_ADDR"); addr == "" {
 		addr = "http://127.0.0.1:8500"
-		log.Warn("CONSUL_HTTP_ADDR was not set, defaulting to http://localhost:8500")
+		log.Warn("CONSUL_HTTP_ADDR was not set, defaulting to http://127.0.0.1:8500")
 	}
 
 	if token = os.Getenv("CONSUL_HTTP_TOKEN"); token == "" {


### PR DESCRIPTION
Add a health check which fires for ongoing testing after a cluster has been determined to be successfully bootstrapped. Rather than blindly returning 200, this will now fire a request to `/v1/status/leader` to test that the client is still responding, and raft looks healthy.

Closes #1 